### PR TITLE
Put results into $ARTIFACTS and reduce hyperkube build logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ TEST_IMAGE_NAME=azure-cloud-controller-manager-test
 TEST_IMAGE=$(TEST_IMAGE_NAME):$(IMAGE_TAG)
 
 WORKSPACE ?= $(shell pwd)
+ARTIFACTS ?= $(WORKSPACE)/_artifacts
 
 all: $(BIN_DIR)/azure-cloud-controller-manager
 
@@ -84,7 +85,7 @@ test-e2e: image hyperkube
 		--build-arg ACSENGINE_VERSION=$(ACSENGINE_VERSION) \
 		tests/k8s-azure
 	docker run --env-file $(K8S_AZURE_ACCOUNT_CONFIG) \
-		-e K8S_AZURE_TEST_ARTIFACTS_DIR=$(WORKSPACE)/_artifacts \
+		-e K8S_AZURE_TEST_ARTIFACTS_DIR=$(ARTIFACTS) \
 		-v $(WORKSPACE):$(WORKSPACE) \
 		$(TEST_IMAGE) e2e -v -caccm_image=$(IMAGE) \
 		-ctype=$(SUITE) \

--- a/scripts/build-hyperkube.sh
+++ b/scripts/build-hyperkube.sh
@@ -41,5 +41,5 @@ if [ "$BRANCH" != "" ]; then
 fi
 
 VERSION=$(git rev-parse --short=7 HEAD)
-VERSION=$VERSION REGISTRY=$REGISTRY hack/dev-push-hyperkube.sh >&2
+VERSION=$VERSION REGISTRY=$REGISTRY KUBE_VERBOSE=1 hack/dev-push-hyperkube.sh >&2
 echo -n $VERSION


### PR DESCRIPTION
Refer #75

> Junit output should be stored in the directory specified by the $ARTIFACTS environment variable and in files with names that match the regexp: junit.*\.xml