### PR TITLE
Update tests and docs to use aks-engine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOMETALINTER_OPTION=--tests --disable-all -E gofmt -E vet -E golint
 
 IMAGE_REGISTRY ?= local
 K8S_VERSION ?= v1.13.0-alpha.3
-ACSENGINE_VERSION ?= v0.25.0
+AKSENGINE_VERSION ?= v0.31.0
 HYPERKUBE_IMAGE ?= "gcrio.azureedge.net/google_containers/hyperkube-amd64:$(K8S_VERSION)"
 # manifest name under tests/e2e/k8s-azure/manifest
 TEST_MANIFEST ?= linux
@@ -82,7 +82,7 @@ test-e2e: image hyperkube
 	docker push $(IMAGE)
 	docker build -t $(TEST_IMAGE) \
 		--build-arg K8S_VERSION=$(K8S_VERSION) \
-		--build-arg ACSENGINE_VERSION=$(ACSENGINE_VERSION) \
+		--build-arg AKSENGINE_VERSION=$(AKSENGINE_VERSION) \
 		tests/k8s-azure
 	docker run --env-file $(K8S_AZURE_ACCOUNT_CONFIG) \
 		-e K8S_AZURE_TEST_ARTIFACTS_DIR=$(ARTIFACTS) \

--- a/docs/azuredisk-issues.md
+++ b/docs/azuredisk-issues.md
@@ -334,7 +334,7 @@ This issue is by design as in Azure, there are two kinds of disks, blob based(un
 
 **Solution**:
 
-Use `default` azure disk storage class in acs-engine, as `default` will always be identical to the agent pool, that is, if VM is managed, it will be managed azure disk class, if unmanaged, then it's unmanaged disk class.
+Use `default` azure disk storage class in aks-engine, as `default` will always be identical to the agent pool, that is, if VM is managed, it will be managed azure disk class, if unmanaged, then it's unmanaged disk class.
 
 ## 9. dynamic azure disk PVC try to access wrong storage account (of other resource group)
 
@@ -362,7 +362,7 @@ Failed to provision volume with StorageClass "default": azureDisk - account ds6c
 
 **Work around**:
 
-this bug only exists in blob based VM in v1.8.x, v1.9.x, so if specify `ManagedDisks` when creating k8s cluster in acs-engine(AKS is using managed disk by default), it won't have this issue:
+this bug only exists in blob based VM in v1.8.x, v1.9.x, so if specify `ManagedDisks` when creating k8s cluster in aks-engine(AKS is using managed disk by default), it won't have this issue:
 
 ```json
     "agentPoolProfiles": [

--- a/docs/azurefile-issues.md
+++ b/docs/azurefile-issues.md
@@ -7,7 +7,7 @@
     - [1. azure file mountOptions setting](#1-azure-file-mountoptions-setting)
         - [file/dir mode setting:](#filedir-mode-setting)
         - [other useful `mountOptions` setting:](#other-useful-mountoptions-setting)
-    - [2. permission issue of azure file dynamic provision in acs-engine](#2-permission-issue-of-azure-file-dynamic-provision-in-acs-engine)
+    - [2. permission issue of azure file dynamic provision in aks-engine](#2-permission-issue-of-azure-file-dynamic-provision-in-aks-engine)
     - [3. Azure file support on Sovereign Cloud](#3-azure-file-support-on-sovereign-cloud)
     - [4. azure file dynamic provision failed due to cluster name length issue](#4-azure-file-dynamic-provision-failed-due-to-cluster-name-length-issue)
     - [5. azure file dynamic provision failed due to no storage account in current resource group](#5-azure-file-dynamic-provision-failed-due-to-no-storage-account-in-current-resource-group)
@@ -68,7 +68,7 @@ Error: SQLITE_BUSY: database is locked
 - [Allow nobrl parameter like docker to use sqlite over network drive](https://github.com/kubernetes/kubernetes/issues/61767)
 - [Error to deploy mongo with azure file storage](https://github.com/kubernetes/kubernetes/issues/58308)
 
-## 2. permission issue of azure file dynamic provision in acs-engine
+## 2. permission issue of azure file dynamic provision in aks-engine
 
 **Issue details**:
 

--- a/docs/cloud-controller-manager.md
+++ b/docs/cloud-controller-manager.md
@@ -41,7 +41,7 @@ To use cloud controller manager, the following components need to be configured:
 
     For details of those flags, please refer to this [doc](https://kubernetes.io/docs/reference/command-line-tools-reference/cloud-controller-manager/).
 
-Alternatively, you can use [acs-engine](https://github.com/Azure/acs-engine) to deploy a Kubernetes cluster running with cloud-controller-manager. It supports deploying `Kubernetes azure-cloud-controller-manager` for Kubernetes v1.8+.
+Alternatively, you can use [aks-engine](https://github.com/Azure/aks-engine) to deploy a Kubernetes cluster running with cloud-controller-manager. It supports deploying `Kubernetes azure-cloud-controller-manager` for Kubernetes v1.8+.
 
 ## Development
 Build project:

--- a/docs/cloud-provider-config.md
+++ b/docs/cloud-provider-config.md
@@ -41,7 +41,7 @@ Note: All values are of string type if not explicitly called out.
 
 Note: Cloud provider currently supports three authentication methods, you can choose one combination of them:
 - [Managed Identity](https://docs.microsoft.com/en-us/azure/active-directory/managed-service-identity/overview): set `useManagedIdentityExtension` to true
-- [Service Principal](https://github.com/Azure/acs-engine/blob/master/docs/serviceprincipal.md): set `aadClientID` and `aadClientSecret`
+- [Service Principal](https://github.com/Azure/aks-engine/blob/master/docs/topics/service-principals.md): set `aadClientID` and `aadClientSecret`
 - [Client Certificate](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-protocols-oauth-service-to-service): set `aadClientCertPath` and `aadClientCertPassword`
 
 If more than one value is set, the order is `Managed Identity` > `Service Principal` > `Client Certificate`.

--- a/docs/component-versioning.md
+++ b/docs/component-versioning.md
@@ -32,10 +32,10 @@ Following Kubernetes versions should stick to Kubernetes package version specifi
  
      Update `FROM golang:* AS build_kubernetes`. This should stick to the Go version used by [Kubernetes](https://github.com/kubernetes/kubernetes/blob/master/build/build-image/cross/Dockerfile)
 
-### 3. acs-engine in E2E test
+### 3. aks-engine in E2E test
    Edit file [Dockerfile](/tests/k8s-azure/Dockerfile)
 
-   Update `ARG ACSENGINE_VERSION=` for acs-engine version.
+   Update `ARG AKSENGINE_VERSION=` for aks-engine version.
 
-   Update `FROM golang:* AS build_acs-engine`.
-   This should stick to the Go version used by [acs-engine](https://github.com/Azure/acs-engine/blob/master/Dockerfile).
+   Update `FROM golang:* AS build_aks-engine`.
+   This should stick to the Go version used by [aks-engine](https://github.com/Azure/aks-engine/blob/master/releases/Dockerfile.linux).

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -3,7 +3,7 @@
 ## Prerequisite
 - An azure service principal
 
-    Please follow this [guide](https://github.com/Azure/acs-engine/blob/v0.14.0/docs/serviceprincipal.md) for creating an azure service principal
+    Please follow this [guide](https://github.com/Azure/aks-engine/blob/master/docs/topics/service-principals.md) for creating an azure service principal
     The service principal should either have:
     - Contributor permission of a subscription
     - Contributor permission of a resource group. In this case, please create the resource group first
@@ -13,22 +13,22 @@
 ### 1. Without container
 
 1. Prepare dependency project
-- [acs-engine](https://github.com/Azure/acs-engine)
+- [aks-engine](https://github.com/Azure/aks-engine)
 
     It is recommended to use the same version as defined in test [Dockerfile](/tests/k8s-azure/Dockerfile). For example:
     ```
-    ARG ACSENGINE_VERSION=v0.18.1
+    ARG AKSENGINE_VERSION=v0.31.0
     ```
 
-    Build acs-engine, and make acs-engine binary in PATH environment variable.
+    Build aks-engine, and make aks-engine binary in PATH environment variable.
 
     ```
-    go get -d github.com/Azure/acs-engine
-    pushd $GOPATH/src/github.com/Azure/acs-engine
+    go get -d github.com/Azure/aks-engine
+    pushd $GOPATH/src/github.com/Azure/aks-engine
     # git checkout <version>
     make
     popd
-    export PATH=$PATH:$GOPATH/src/github.com/Azure/acs-engine/bin
+    export PATH=$PATH:$GOPATH/src/github.com/Azure/aks-engine/bin
     ```
 
 - [Kubernetes](https://github.com/kubernetes/kubernetes)

--- a/tests/k8s-azure/Dockerfile
+++ b/tests/k8s-azure/Dockerfile
@@ -12,11 +12,11 @@ RUN git clone https://github.com/kubernetes/kubernetes . \
     && ./e2e
 RUN rm -rf _output/local/go
 
-FROM golang:1.11.2-stretch AS build_acs-engine
-ARG ACSENGINE_VERSION=v0.25.0
-WORKDIR /go/src/github.com/Azure/acs-engine
-RUN git clone https://github.com/Azure/acs-engine . \
-    && git checkout -b temp $ACSENGINE_VERSION \
+FROM golang:1.11.2-stretch AS build_aks-engine
+ARG AKSENGINE_VERSION=v0.31.0
+WORKDIR /go/src/github.com/Azure/aks-engine
+RUN git clone https://github.com/Azure/aks-engine . \
+    && git checkout -b temp $AKSENGINE_VERSION \
     && make
 
 FROM buildpack-deps:stretch-scm
@@ -36,7 +36,7 @@ COPY --from=build_kubernetes /go/src/k8s.io/kubernetes/cluster $GOPATH/src/k8s.i
 COPY --from=build_kubernetes /go/src/k8s.io/kubernetes/hack $GOPATH/src/k8s.io/kubernetes/hack
 COPY --from=build_kubernetes /go/src/k8s.io/kubernetes/_output $GOPATH/src/k8s.io/kubernetes/_output
 COPY --from=build_kubernetes /go/src/k8s.io/kubernetes/e2e $GOPATH/src/k8s.io/kubernetes/e2e
-COPY --from=build_acs-engine /go/src/github.com/Azure/acs-engine/bin/acs-engine /usr/local/bin/
+COPY --from=build_aks-engine /go/src/github.com/Azure/aks-engine/bin/aks-engine /usr/local/bin/
 COPY k8s-azure skip.txt /opt/k8s-azure/
 COPY manifest /opt/k8s-azure/manifest
 RUN ["/bin/bash", "-c", "ln -s /opt/k8s-azure/k8s-azure /usr/local/bin"]

--- a/tests/k8s-azure/k8s-azure
+++ b/tests/k8s-azure/k8s-azure
@@ -71,7 +71,7 @@ sub deploy {
                 else { 1; }
               }
               && mlog("Creating cluster: $name")
-              && run_cmd("acs-engine deploy --api-model $ENGINE_FILE"
+              && run_cmd("aks-engine deploy --api-model $ENGINE_FILE"
                 . " --azure-env $az_env --subscription-id \$K8S_AZURE_SUBSID --location $location --resource-group $name"
                 . " --auth-method client_secret --client-id \$K8S_AZURE_SPID --client-secret \$K8S_AZURE_SPSEC");
             }),

--- a/tests/k8s-azure/manifest/linux-kcm.json
+++ b/tests/k8s-azure/manifest/linux-kcm.json
@@ -4,7 +4,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.12",
+            "orchestratorRelease": "1.14",
             "kubernetesConfig": {
                 "customHyperkubeImage": "gcrio.azureedge.net/google_containers/hyperkube-amd64:v1.13.0-alpha.3",
                 "networkPolicy": "none",
@@ -16,7 +16,8 @@
         "masterProfile": {
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
-            "vmSize": "Standard_F2"
+            "vmSize": "Standard_F2",
+            "distro": "ubuntu"
         },
         "agentPoolProfiles": [
             {
@@ -24,7 +25,8 @@
                 "count": 2,
                 "vmSize": "Standard_F2",
                 "availabilityProfile": "VirtualMachineScaleSets",
-                "storageProfile": "ManagedDisks"
+                "storageProfile": "ManagedDisks",
+                "distro": "ubuntu"
             }
         ],
         "linuxProfile": {

--- a/tests/k8s-azure/manifest/linux.json
+++ b/tests/k8s-azure/manifest/linux.json
@@ -4,7 +4,7 @@
     "properties": {
         "orchestratorProfile": {
             "orchestratorType": "Kubernetes",
-            "orchestratorRelease": "1.12",
+            "orchestratorRelease": "1.14",
             "kubernetesConfig": {
                 "useCloudControllerManager": true,
                 "customCcmImage": "gcrio.azureedge.net/google_containers/cloud-controller-manager-amd64:v1.13.0-alpha.3",
@@ -18,7 +18,8 @@
         "masterProfile": {
             "count": 1,
             "dnsPrefix": "{dnsPrefix}",
-            "vmSize": "Standard_F2"
+            "vmSize": "Standard_F2",
+            "distro": "ubuntu"
         },
         "agentPoolProfiles": [
             {
@@ -26,7 +27,8 @@
                 "count": 2,
                 "vmSize": "Standard_F2",
                 "availabilityProfile": "AvailabilitySet",
-                "storageProfile": "ManagedDisks"
+                "storageProfile": "ManagedDisks",
+                "distro": "ubuntu"
             }
         ],
         "linuxProfile": {


### PR DESCRIPTION
- Update e2e test to use aks-engine release v0.31.0 with https://github.com/Azure/aks-engine/pull/492 to fix broken prow job: https://testgrid.k8s.io/sig-azure-master#azure-master-conformance
- Update the apimodel manifest to v1.14 so that aks-engine can remove deprecated flag
- Update docs where applicable

NOTE: The long term fix to point aks-engine release to a url from storage blob, instead of updating releases, will be in a followup PR after the prow job issue has been fixed.

cc @feiskyer @PatrickLang 

**Notes**:
```release-note
Update tests and docs to use aks-engine v0.31.0 to fix e2e tests
```