### PR TITLE
Bump aks-engine to v0.31.1 to support private ACR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOMETALINTER_OPTION=--tests --disable-all -E gofmt -E vet -E golint
 
 IMAGE_REGISTRY ?= local
 K8S_VERSION ?= v1.13.0-alpha.3
-AKSENGINE_VERSION ?= v0.31.0
+AKSENGINE_VERSION ?= v0.31.1
 HYPERKUBE_IMAGE ?= "gcrio.azureedge.net/google_containers/hyperkube-amd64:$(K8S_VERSION)"
 # manifest name under tests/e2e/k8s-azure/manifest
 TEST_MANIFEST ?= linux

--- a/docs/e2e-tests.md
+++ b/docs/e2e-tests.md
@@ -17,7 +17,7 @@
 
     It is recommended to use the same version as defined in test [Dockerfile](/tests/k8s-azure/Dockerfile). For example:
     ```
-    ARG AKSENGINE_VERSION=v0.31.0
+    ARG AKSENGINE_VERSION=v0.31.1
     ```
 
     Build aks-engine, and make aks-engine binary in PATH environment variable.

--- a/tests/k8s-azure/Dockerfile
+++ b/tests/k8s-azure/Dockerfile
@@ -13,7 +13,7 @@ RUN git clone https://github.com/kubernetes/kubernetes . \
 RUN rm -rf _output/local/go
 
 FROM golang:1.11.2-stretch AS build_aks-engine
-ARG AKSENGINE_VERSION=v0.31.0
+ARG AKSENGINE_VERSION=v0.31.1
 WORKDIR /go/src/github.com/Azure/aks-engine
 RUN git clone https://github.com/Azure/aks-engine . \
     && git checkout -b temp $AKSENGINE_VERSION \

--- a/tests/k8s-azure/k8s-azure
+++ b/tests/k8s-azure/k8s-azure
@@ -67,7 +67,12 @@ sub deploy {
                 else { 1; }
               }
               && do {
-                if ($hyperkube_image) {edit_file($ENGINE_FILE, sub { s/"customHyperkubeImage":\h*"\K.*"/$hyperkube_image"/ }); }
+                if ($hyperkube_image) {
+                  edit_file($ENGINE_FILE, sub { s/"customHyperkubeImage":\h*"\K.*"/$hyperkube_image"/ }); 
+                  my $myindex = index $hyperkube_image "/";
+                  my $private_azure_registry_server = substr $hyperkube_image, 0, $myindex;
+                  edit_file($ENGINE_FILE, sub { s/"privateAzureRegistryServer":\h*"\K.*"/$private_azure_registry_server"/ }); 
+                }
                 else { 1; }
               }
               && mlog("Creating cluster: $name")

--- a/tests/k8s-azure/k8s-azure
+++ b/tests/k8s-azure/k8s-azure
@@ -68,10 +68,13 @@ sub deploy {
               }
               && do {
                 if ($hyperkube_image) {
+                  my $contains_index = index $hyperkube_image, "azurecr";
+                  if ($contains_index != -1) {
+                    my $myindex = index $hyperkube_image, "/";
+                    my $private_azure_registry_server = substr $hyperkube_image, 0, $myindex;
+                    edit_file($ENGINE_FILE, sub { s/"privateAzureRegistryServer":\h*"\K.*"/$private_azure_registry_server"/ }); 
+                  }
                   edit_file($ENGINE_FILE, sub { s/"customHyperkubeImage":\h*"\K.*"/$hyperkube_image"/ }); 
-                  my $myindex = index $hyperkube_image "/";
-                  my $private_azure_registry_server = substr $hyperkube_image, 0, $myindex;
-                  edit_file($ENGINE_FILE, sub { s/"privateAzureRegistryServer":\h*"\K.*"/$private_azure_registry_server"/ }); 
                 }
                 else { 1; }
               }

--- a/tests/k8s-azure/manifest/linux-kcm.json
+++ b/tests/k8s-azure/manifest/linux-kcm.json
@@ -7,6 +7,7 @@
             "orchestratorRelease": "1.14",
             "kubernetesConfig": {
                 "customHyperkubeImage": "gcrio.azureedge.net/google_containers/hyperkube-amd64:v1.13.0-alpha.3",
+                "privateAzureRegistryServer": "gcrio.azureedge.net",
                 "networkPolicy": "none",
                 "apiServerConfig": {
                     "--enable-admission-plugins": "NamespaceLifecycle,LimitRanger,ServiceAccount,DefaultStorageClass,ResourceQuota,AlwaysPullImages"


### PR DESCRIPTION
Incorporate aks-engine update: https://github.com/Azure/aks-engine/pull/523

**Notes**:

```release-note
Update tests and docs to use aks-engine v0.31.1 to support private ACR to fix e2e tests
```