### PR TITLE
Fix resource group name for the cluster

### DIFF
--- a/tests/e2e/utils/azure_test_client.go
+++ b/tests/e2e/utils/azure_test_client.go
@@ -17,13 +17,21 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
+	"regexp"
+
 	aznetwork "github.com/Azure/azure-sdk-for-go/services/network/mgmt/2017-09-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )
 
+var (
+	azureResourceGroupNameRE = regexp.MustCompile(`.*/subscriptions/(?:.*)/resourceGroups/(.+)/providers/(?:.*)`)
+)
+
 // AzureTestClient configs Azure specific clients
 type AzureTestClient struct {
+	resourceGroup string
 	networkClient aznetwork.BaseClient
 }
 
@@ -41,7 +49,26 @@ func CreateAzureTestClient() (*AzureTestClient, error) {
 	baseClient := aznetwork.NewWithBaseURI(azure.PublicCloud.TokenAudience, authconfig.SubscriptionID)
 	baseClient.Authorizer = autorest.NewBearerAuthorizer(servicePrincipleToken)
 
+	kubeClient, err := CreateKubeClientSet()
+	if err != nil {
+		return nil, err
+	}
+
+	nodes, err := GetAgentNodes(kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	if len(nodes) == 0 {
+		return nil, fmt.Errorf("no nodes available for the cluster")
+	}
+
+	resourceGroup, err := getResourceGroupFromProviderID(nodes[0].Spec.ProviderID)
+	if err != nil {
+		return nil, err
+	}
+
 	c := &AzureTestClient{
+		resourceGroup: resourceGroup,
 		networkClient: baseClient,
 	}
 
@@ -49,8 +76,8 @@ func CreateAzureTestClient() (*AzureTestClient, error) {
 }
 
 // getResourceGroup get RG name which is same of cluster name as definite in k8s-azure
-func getResourceGroup() string {
-	return ExtractDNSPrefix()
+func (tc *AzureTestClient) getResourceGroup() string {
+	return tc.resourceGroup
 }
 
 // CreateSubnetsClient generates subnet client with the same baseclient as azure test client
@@ -66,4 +93,14 @@ func (tc *AzureTestClient) createVirtualNetworksClient() *aznetwork.VirtualNetwo
 // CreateSecurityGroupsClient generates security group client with the same baseclient as azure test client
 func (tc *AzureTestClient) CreateSecurityGroupsClient() *aznetwork.SecurityGroupsClient {
 	return &aznetwork.SecurityGroupsClient{BaseClient: tc.networkClient}
+}
+
+// getResourceGroupFromProviderID gets the resource group name in the provider ID.
+func getResourceGroupFromProviderID(providerID string) (string, error) {
+	matches := azureResourceGroupNameRE.FindStringSubmatch(providerID)
+	if len(matches) != 2 {
+		return "", fmt.Errorf("%q isn't in Azure resource ID format %q", providerID, azureResourceGroupNameRE.String())
+	}
+
+	return matches[1], nil
 }

--- a/tests/e2e/utils/network_utils.go
+++ b/tests/e2e/utils/network_utils.go
@@ -29,7 +29,7 @@ func (azureTestClient *AzureTestClient) getVirtualNetworkList() (result aznetwor
 	Logf("Getting virtual network list")
 	vNetClient := azureTestClient.createVirtualNetworksClient()
 	err = wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		result, err = vNetClient.List(context.Background(), getResourceGroup())
+		result, err = vNetClient.List(context.Background(), azureTestClient.getResourceGroup())
 		if err != nil {
 			if !IsRetryableAPIError(err) {
 				return false, err
@@ -63,7 +63,7 @@ func (azureTestClient *AzureTestClient) CreateSubnet(vnet aznetwork.VirtualNetwo
 	subnetParameter.Name = subnetName
 	subnetParameter.AddressPrefix = prefix
 	subnetsClient := azureTestClient.createSubnetsClient()
-	_, err := subnetsClient.CreateOrUpdate(context.Background(), getResourceGroup(), *vnet.Name, *subnetName, subnetParameter)
+	_, err := subnetsClient.CreateOrUpdate(context.Background(), azureTestClient.getResourceGroup(), *vnet.Name, *subnetName, subnetParameter)
 	return err
 }
 
@@ -71,7 +71,7 @@ func (azureTestClient *AzureTestClient) CreateSubnet(vnet aznetwork.VirtualNetwo
 func (azureTestClient *AzureTestClient) DeleteSubnet(vnetName string, subnetName string) error {
 	subnetClient := azureTestClient.createSubnetsClient()
 	return wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		_, err := subnetClient.Delete(context.Background(), getResourceGroup(), vnetName, subnetName)
+		_, err := subnetClient.Delete(context.Background(), azureTestClient.getResourceGroup(), vnetName, subnetName)
 		if err != nil {
 			return false, nil
 		}
@@ -98,7 +98,7 @@ func (azureTestClient *AzureTestClient) getSecurityGroupList() (result aznetwork
 	Logf("Getting virtual network list")
 	securityGroupsClient := azureTestClient.CreateSecurityGroupsClient()
 	err = wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
-		result, err = securityGroupsClient.List(context.Background(), getResourceGroup())
+		result, err = securityGroupsClient.List(context.Background(), azureTestClient.getResourceGroup())
 		if err != nil {
 			if !IsRetryableAPIError(err) {
 				return false, err


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind bug

**What this PR does / why we need it**:

The prefix from DNS is not always same with resource group name. We need
to get it from providerID.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
