### PR TITLE
Set timeout to a larger value

### DIFF
--- a/tests/e2e/utils/service_utils.go
+++ b/tests/e2e/utils/service_utils.go
@@ -28,6 +28,10 @@ import (
 	clientset "k8s.io/client-go/kubernetes"
 )
 
+const (
+	serviceTimeout = 20 * time.Minute
+)
+
 // DeleteService deletes a service
 func DeleteService(cs clientset.Interface, ns string, serviceName string) error {
 	err := cs.CoreV1().Services(ns).Delete(serviceName, nil)
@@ -66,7 +70,7 @@ func WaitServiceExposure(cs clientset.Interface, namespace string, name string) 
 	var service *v1.Service
 	var err error
 
-	if wait.PollImmediate(10*time.Second, 10*time.Minute, func() (bool, error) {
+	if wait.PollImmediate(10*time.Second, serviceTimeout, func() (bool, error) {
 		service, err = cs.CoreV1().Services(namespace).Get(name, metav1.GetOptions{})
 		if err != nil {
 			if IsRetryableAPIError(err) {

--- a/tests/e2e/utils/utils.go
+++ b/tests/e2e/utils/utils.go
@@ -33,7 +33,7 @@ import (
 const (
 	deletionTimeout   = 10 * time.Minute
 	poll              = 2 * time.Second
-	singleCallTimeout = 5 * time.Minute
+	singleCallTimeout = 10 * time.Minute
 )
 
 func findExistingKubeConfig() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind failing-test

**What this PR does / why we need it**:

The current e2e tests are pretty flaky, set the timeouts to large values for reducing the failing tests.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:


**Release note**:
```
NONE
```
