### PR TITLE
Make autoscaler e2e test more stable

### DIFF
--- a/tests/e2e/utils/node_utils.go
+++ b/tests/e2e/utils/node_utils.go
@@ -54,10 +54,7 @@ func getNodeList(cs clientset.Interface) (*v1.NodeList, error) {
 	if wait.PollImmediate(poll, singleCallTimeout, func() (bool, error) {
 		nodes, err = cs.CoreV1().Nodes().List(metav1.ListOptions{})
 		if err != nil {
-			if IsRetryableAPIError(err) {
-				return false, nil
-			}
-			return false, err
+			return false, nil
 		}
 		return true, nil
 	}) != nil {
@@ -132,8 +129,8 @@ func WaitAutoScaleNodes(cs clientset.Interface, targetNodeCount int) error {
 	Logf(fmt.Sprintf("waiting for auto-scaling the node... Target node count: %v", targetNodeCount))
 	var nodes []v1.Node
 	var err error
-	poll := 20 * time.Second
-	autoScaleTimeOut := 30 * time.Minute
+	poll := 60 * time.Second
+	autoScaleTimeOut := 50 * time.Minute
 	if wait.PollImmediate(poll, autoScaleTimeOut, func() (bool, error) {
 		nodes, err = GetAgentNodes(cs)
 		if err != nil {

--- a/tests/e2e/utils/pod_utils.go
+++ b/tests/e2e/utils/pod_utils.go
@@ -47,6 +47,22 @@ func getPodList(cs clientset.Interface, ns string) (*v1.PodList, error) {
 	return pods, nil
 }
 
+// LogPodStatus logs the rate of pending
+func LogPodStatus(cs clientset.Interface, ns string) error {
+	pods, err := getPodList(cs, ns)
+	if err != nil {
+		return err
+	}
+	pendingPodCount := 0
+	for _, p := range pods.Items {
+		if p.Status.Phase == v1.PodPending {
+			pendingPodCount++
+		}
+	}
+	Logf("%d of %d pods in namespace %s are pending", pendingPodCount, len(pods.Items), ns)
+	return nil
+}
+
 // DeletePodsInNamespace deletes all pods in the namespace
 func DeletePodsInNamespace(cs clientset.Interface, ns string) error {
 	Logf("Deleting all pods in namespace %s", ns)


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
Autoscaler e2e test exceeds time or returns 'Unexpected EOF' error
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
**Release note**:
```
none
```
