### PR TITLE
Convert json-based logs to slightly more human-readable logs

### DIFF
--- a/hack/log-dump/log-dump.sh
+++ b/hack/log-dump/log-dump.sh
@@ -133,7 +133,7 @@ trap cleanup EXIT
 function main() {
   echo "Installing log-dump-daemonset.yaml via kubectl"
   kubectl apply -f "${script_dir}/log-dump-daemonset.yaml"
-  kubectl wait --for condition=ready pod --all --timeout=1m
+  kubectl wait --for condition=ready pod -l app=log-dump-node --timeout=5m
   echo "All pods from log-dump-daemonset are ready"
   kubectl get pod -owide
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/release.md#issue-kind-label
3. Ensure you have added or ran the appropriate tests for your PR: https://git.k8s.io/community/contributors/devel/testing.md
4. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
5. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
6. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

/kind cleanup

**What this PR does / why we need it**:

Convert json-based logs to slightly more human-readable logs.

Convert logs from
```json
{"log":"I1023 16:42:02.680863       1 flags.go:33] FLAG: --add-dir-header=\"false\"\n","stream":"stderr","time":"2019-10-23T16:42:02.681030225Z"}
{"log":"I1023 16:42:02.681103       1 flags.go:33] FLAG: --address=\"0.0.0.0\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682702607Z"}
{"log":"I1023 16:42:02.681115       1 flags.go:33] FLAG: --allocate-node-cidrs=\"true\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682712907Z"}
{"log":"I1023 16:42:02.681121       1 flags.go:33] FLAG: --allow-untagged-cloud=\"false\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682715707Z"}
{"log":"I1023 16:42:02.681124       1 flags.go:33] FLAG: --alsologtostderr=\"false\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682718507Z"}
{"log":"I1023 16:42:02.681128       1 flags.go:33] FLAG: --authentication-kubeconfig=\"\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682720907Z"}
{"log":"I1023 16:42:02.681132       1 flags.go:33] FLAG: --authentication-skip-lookup=\"false\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682723407Z"}
{"log":"I1023 16:42:02.681144       1 flags.go:33] FLAG: --authentication-token-webhook-cache-ttl=\"10s\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682725707Z"}
{"log":"I1023 16:42:02.681150       1 flags.go:33] FLAG: --authentication-tolerate-lookup-failure=\"false\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682728207Z"}
{"log":"I1023 16:42:02.681153       1 flags.go:33] FLAG: --authorization-always-allow-paths=\"[/healthz]\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682730707Z"}
{"log":"I1023 16:42:02.681163       1 flags.go:33] FLAG: --authorization-kubeconfig=\"\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682733107Z"}
{"log":"I1023 16:42:02.681166       1 flags.go:33] FLAG: --authorization-webhook-cache-authorized-ttl=\"10s\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682735506Z"}
{"log":"I1023 16:42:02.681169       1 flags.go:33] FLAG: --authorization-webhook-cache-unauthorized-ttl=\"10s\"\n","stream":"stderr","time":"2019-10-23T16:42:02.682738006Z"}
...
```

to
```log
I1023 19:08:35.024789       1 flags.go:33] FLAG: --add-dir-header="false"
I1023 19:08:35.024834       1 flags.go:33] FLAG: --address="0.0.0.0"
I1023 19:08:35.024840       1 flags.go:33] FLAG: --allocate-node-cidrs="true"
I1023 19:08:35.024845       1 flags.go:33] FLAG: --allow-untagged-cloud="false"
I1023 19:08:35.024849       1 flags.go:33] FLAG: --alsologtostderr="false"
I1023 19:08:35.024852       1 flags.go:33] FLAG: --authentication-kubeconfig=""
I1023 19:08:35.024857       1 flags.go:33] FLAG: --authentication-skip-lookup="false"
I1023 19:08:35.024860       1 flags.go:33] FLAG: --authentication-token-webhook-cache-ttl="10s"
I1023 19:08:35.024865       1 flags.go:33] FLAG: --authentication-tolerate-lookup-failure="false"
I1023 19:08:35.024868       1 flags.go:33] FLAG: --authorization-always-allow-paths="[/healthz]"
I1023 19:08:35.024877       1 flags.go:33] FLAG: --authorization-kubeconfig=""
I1023 19:08:35.024881       1 flags.go:33] FLAG: --authorization-webhook-cache-authorized-ttl="10s"
I1023 19:08:35.024884       1 flags.go:33] FLAG: --authorization-webhook-cache-unauthorized-ttl="10s"
...
```

Also added label selection and increased timeout duration when waiting for log dump pods to become ready in response to this recent error from [ci-cloud-provider-azure-multiple-zones](https://prow.k8s.io/view/gcs/kubernetes-jenkins/logs/ci-cloud-provider-azure-multiple-zones/1187448294901551104):
```
I1024 21:26:11.470] daemonset.apps/log-dump-node created
I1024 21:26:37.832] pod/log-dump-node-6nhqd condition met
I1024 21:26:38.261] pod/log-dump-node-8gt8l condition met
I1024 21:26:39.966] pod/log-dump-node-hrqmd condition met
I1024 21:27:40.105] pod/log-dump-node-jzcpz condition met
I1024 21:27:40.143] pod/log-dump-node-t72qh condition met
I1024 21:27:40.182] pod/log-dump-node-tzk7k condition met
W1024 21:28:40.254] timed out waiting for the condition on pods/log-dump-node-j2grn
W1024 21:28:40.255] timed out waiting for the condition on pods/recycler-for-nfs-gctbq
```

Also, this PR will cause the script to continue running even if some pods from the DaemonSet failed to run.

**Which issue(s) this PR fixes**:
<!-- 
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Follow-up PR for #248

**Special notes for your reviewer**:


**Release note**:
```
None.
```

/assign @feiskyer 
